### PR TITLE
fix: remove unsupported networks from ui

### DIFF
--- a/src/components/ExplorerTable/ExplorerTable.tsx
+++ b/src/components/ExplorerTable/ExplorerTable.tsx
@@ -16,6 +16,7 @@ import {
   formatAmountDecimals,
   renderAmountValue,
   renderFormatedConvertedAmount,
+  filterTransfers,
 } from "../../utils/Helpers"
 import { useStyles } from "./styles"
 
@@ -144,7 +145,7 @@ const ExplorerTable: React.FC<ExplorerTable> = ({ state, sharedConfig }: Explore
           <TableCell sx={{ borderTopRightRadius: "12px !important" }}>Value</TableCell>
         </TableRow>
       </TableHead>
-      {state.loading === "done" && <TableBody>{renderTransferList(state.transfers)}</TableBody>}
+      {state.loading === "done" && <TableBody>{renderTransferList(filterTransfers(state.transfers, sharedConfig))}</TableBody>}
       {state.loading === "loading" && (
         <TableBody>
           <TableRow>

--- a/src/utils/Helpers.tsx
+++ b/src/utils/Helpers.tsx
@@ -315,3 +315,18 @@ export const accountLinks = (type: DomainTypes, accountId: string, domainExplore
       return ""
   }
 }
+
+export const filterTransfers = (transfers: Transfer[], sharedConfig: SharedConfigDomain[]) => {
+
+  return transfers.filter((transfer) => {
+    const { fromDomainId, toDomainId } = transfer
+  
+    const fromDomainInfo = getDomainData(fromDomainId, sharedConfig)
+    const toDomainInfo = getDomainData(toDomainId, sharedConfig)
+    if(!fromDomainInfo || !toDomainInfo) {
+      return
+    }
+  
+    return transfer
+  })
+}


### PR DESCRIPTION
remove unsupported networks from ui
## Description
We removed base-goerli and goerli from shared-config, this caused UI to break

## Related Issue Or Context

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change here -->

Closes: #<issue>

## How Has This Been Tested? Testing details.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in sygma-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
